### PR TITLE
Changed background type for authentication screens

### DIFF
--- a/ContentApp/BusinessLayer/Constants/Constants.swift
+++ b/ContentApp/BusinessLayer/Constants/Constants.swift
@@ -85,7 +85,6 @@ let listBottomInset: CGFloat = 63.0
 // MARK: -
 let kDefaultLoginUnsecuredPort = "80"
 let kDefaultLoginSecuredPort = "443"
-let kPushAnimation = (UIDevice.current.userInterfaceIdiom != .pad)
 let kWindow =  UIApplication.shared.windows[0]
 let kIndexPathZero = IndexPath(row: 0, section: 0)
 let kPlayerBackForWardTime: Double = 10

--- a/ContentApp/PresentationLayer/Authentication/Screens/AimsViewController.swift
+++ b/ContentApp/PresentationLayer/Authentication/Screens/AimsViewController.swift
@@ -133,8 +133,7 @@ class AimsViewController: SystemThemableViewController {
         copyrightLabel.textAlignment = .center
         productLabel.textAlignment = .center
 
-        view.backgroundColor =
-            (UIDevice.current.userInterfaceIdiom == .pad) ? .clear : currentTheme.surfaceColor
+        view.backgroundColor = currentTheme.surfaceColor
     }
 }
 

--- a/ContentApp/PresentationLayer/Authentication/Screens/BasicAuthViewController.swift
+++ b/ContentApp/PresentationLayer/Authentication/Screens/BasicAuthViewController.swift
@@ -154,8 +154,7 @@ class BasicAuthViewController: SystemThemableViewController {
 
         applyThemingInTextField(errorTheme: false)
 
-        view.backgroundColor =
-            (UIDevice.current.userInterfaceIdiom == .pad) ? .clear : currentTheme.surfaceColor
+        view.backgroundColor = currentTheme.surfaceColor
     }
 
     func applyThemingInTextField(errorTheme: Bool) {

--- a/ContentApp/PresentationLayer/Authentication/Screens/ConnectViewController.swift
+++ b/ContentApp/PresentationLayer/Authentication/Screens/ConnectViewController.swift
@@ -164,8 +164,7 @@ class ConnectViewController: SystemThemableViewController {
         copyrightLabel.textAlignment = .center
         productLabel.textAlignment = .center
 
-        view.backgroundColor =
-            (UIDevice.current.userInterfaceIdiom == .pad) ? .clear : currentTheme.surfaceColor
+        view.backgroundColor = currentTheme.surfaceColor
 
         let image = UIImage(color: currentTheme.surfaceColor,
                             size: navigationController?.navigationBar.bounds.size)

--- a/ContentApp/PresentationLayer/Authentication/Sub-Coordinators/ConnectScreenCoordinator.swift
+++ b/ContentApp/PresentationLayer/Authentication/Sub-Coordinators/ConnectScreenCoordinator.swift
@@ -72,7 +72,7 @@ class ConnectScreenCoordinator: Coordinator {
     }
 
     func popViewController() {
-        self.containerViewNavigationController?.popViewController(animated: kPushAnimation)
+        self.containerViewNavigationController?.popViewController(animated: true)
     }
 }
 

--- a/ContentApp/PresentationLayer/Storyboard/Base.lproj/Main.storyboard
+++ b/ContentApp/PresentationLayer/Storyboard/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                             </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="1gE-re-QQi" secondAttribute="trailing" constant="20" id="0kb-eE-c30"/>


### PR DESCRIPTION
Previously the authentication screens were themed with clear backgrounds to create a translucent effect with the underlaying background images. Since the UI was overhauled for those screens it is no longer necessary.

 Resolves: #MOBILEAPPS-599