### PR TITLE
Recalculate size when change orientation for activity indicator

### DIFF
--- a/ContentApp/PresentationLayer/Components/ActivityIndicatorView.swift
+++ b/ContentApp/PresentationLayer/Components/ActivityIndicatorView.swift
@@ -69,6 +69,7 @@ class ActivityIndicatorView: UIView {
 
     func recalculateSize(_ size: CGSize) {
         frame.size = size
+        overlayView?.frame = frame
     }
 
     // MARK: - Private Helpers


### PR DESCRIPTION
iPad - Shadows displayed on Sign in screens after changing the orientation
Resolves: #MOBILEAPPS-627