### PR TITLE
Improved note status reporting in UI

### DIFF
--- a/ContentApp/BusinessLayer/Action Menu/ViewModels/NodeActionsViewModel.swift
+++ b/ContentApp/BusinessLayer/Action Menu/ViewModels/NodeActionsViewModel.swift
@@ -154,6 +154,7 @@ class NodeActionsViewModel {
             if let queriedNode = listNodeDataAccessor.query(node: node) {
                 queriedNode.markedAsOffline = false
                 queriedNode.markedFor = .removal
+                queriedNode.syncStatus = .undefined
                 listNodeDataAccessor.store(node: queriedNode)
             }
 

--- a/ContentApp/BusinessLayer/Lists/Models/ListNode.swift
+++ b/ContentApp/BusinessLayer/Lists/Models/ListNode.swift
@@ -86,7 +86,7 @@ class ListNode: Hashable, Entity {
     var modifiedAt: Date?
     var favorite: Bool?
     var trashed: Bool?
-    var markedAsOffline: Bool? = false
+    var markedAsOffline = false
 
     // objectbox: convert = { "default": ".unknown" }
     var nodeType: NodeType
@@ -164,21 +164,6 @@ class ListNode: Hashable, Entity {
         self.markedFor = newVersion.markedFor
     }
 
-    func syncStatusIcon() -> UIImage? {
-        switch self.syncStatus {
-        case .error:
-            return UIImage(named: "ic-sync-status-error")
-        case .pending:
-            return UIImage(named: "ic-sync-status-pending")
-        case .inProgress:
-            return UIImage(named: "ic-sync-status-in-progress")
-        case .synced:
-            return UIImage(named: "ic-sync-status-synced")
-        case .undefined:
-            return UIImage(named: "ic-sync-status-pending")
-        }
-    }
-
     static func == (lhs: ListNode, rhs: ListNode) -> Bool {
         return lhs.guid == rhs.guid
     }
@@ -196,6 +181,11 @@ class ListNode: Hashable, Entity {
     func isMarkedOffline() -> Bool {
         let dataAccessor = ListNodeDataAccessor()
         return dataAccessor.isNodeMarkedAsOffline(node: self)
+    }
+
+    func hasSyncStatus() -> SyncStatus {
+        let dataAccessor = ListNodeDataAccessor()
+        return dataAccessor.syncStatus(for: self)
     }
 
     func hasPersmission(to type: AllowableOperationsType) -> Bool {

--- a/ContentApp/BusinessLayer/Lists/ViewModels/Protocols/ListComponentDataSourceProtocol.swift
+++ b/ContentApp/BusinessLayer/Lists/ViewModels/Protocols/ListComponentDataSourceProtocol.swift
@@ -19,6 +19,15 @@
 import Foundation
 import AlfrescoContent
 
+enum ListEntrySyncStatus: String {
+    case markedForOffline = "ic-sync-status-marked"
+    case error = "ic-sync-status-error"
+    case pending = "ic-sync-status-pending"
+    case inProgress = "ic-sync-status-in-progress"
+    case synced = "ic-sync-status-synced"
+    case undefined = ""
+}
+
 protocol ListComponentDataSourceProtocol: class {
     func isEmpty() -> Bool
     func emptyList() -> EmptyListProtocol
@@ -38,7 +47,7 @@ protocol ListComponentDataSourceProtocol: class {
     func shouldDisplayListActionButton() -> Bool
     func shouldEnableListActionButton() -> Bool
     func shouldPreview(node: ListNode) -> Bool
-    func shoulDisplayOfflineIcon() -> Bool
+    func syncStatus(for node: ListNode) -> ListEntrySyncStatus
 }
 
 extension ListComponentDataSourceProtocol {
@@ -71,15 +80,15 @@ extension ListComponentDataSourceProtocol {
         return true
     }
 
-    func shoulDisplayOfflineIcon() -> Bool {
-        return true
-    }
-
     func listActionTitle() -> String? {
         return nil
     }
 
     func titleForSectionHeader(at indexPath: IndexPath) -> String {
         return ""
+    }
+
+    func syncStatus(for node: ListNode) -> ListEntrySyncStatus {
+        return node.isMarkedOffline() ? .markedForOffline : .undefined
     }
 }

--- a/ContentApp/PersistenceLayer/DataAccessors/ListNodeDataAccessor.swift
+++ b/ContentApp/PersistenceLayer/DataAccessors/ListNodeDataAccessor.swift
@@ -146,7 +146,12 @@ class ListNodeDataAccessor {
 
     func isNodeMarkedAsOffline(node: ListNode) -> Bool {
         guard let node = query(node: node) else { return false }
-        return node.markedAsOffline ?? false
+        return node.markedAsOffline
+    }
+
+    func syncStatus(for node: ListNode) -> SyncStatus {
+        guard let node = query(node: node) else { return .undefined }
+        return node.syncStatus
     }
 
     // MARK: - Path construction
@@ -219,7 +224,7 @@ class ListNodeDataAccessor {
 
     private func removeChildren(of node: ListNode) {
         if let children = children(of: node) {
-            for listNode in children where listNode.markedAsOffline == false || listNode.markedAsOffline == nil {
+            for listNode in children where listNode.markedAsOffline == false {
                 if listNode.nodeType == .folder {
                     removeChildren(of: listNode)
                 } else {

--- a/ContentApp/PresentationLayer/Components/ListComponentViewController.swift
+++ b/ContentApp/PresentationLayer/Components/ListComponentViewController.swift
@@ -282,23 +282,23 @@ extension ListComponentViewController: UICollectionViewDelegateFlowLayout,
     func collectionView(_ collectionView: UICollectionView,
                         cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let node = listDataSource?.listNode(for: indexPath) else { return UICollectionViewCell() }
-
         let identifier = String(describing: ListElementCollectionViewCell.self)
+
         let cell =
             collectionView.dequeueReusableCell(withReuseIdentifier: identifier,
                                                for: indexPath) as? ListElementCollectionViewCell
-        cell?.element = node
+        cell?.node = node
         cell?.delegate = self
         cell?.applyTheme(coordinatorServices?.themingService?.activeTheme)
+        cell?.syncStatus = listDataSource?.syncStatus(for: node) ?? .undefined
+
         if node.nodeType == .fileLink || node.nodeType == .folderLink {
             cell?.moreButton.isHidden = true
         }
         if listDataSource?.shouldDisplayNodePath() == false {
             cell?.subtitle.text = ""
         }
-        if listDataSource?.shoulDisplayOfflineIcon() == true {
-            cell?.syncStatusImageView.image = UIImage(named: "ic-sync-status-marked")
-        }
+
         return cell ?? UICollectionViewCell()
     }
 

--- a/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.swift
+++ b/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.swift
@@ -19,7 +19,8 @@
 import UIKit
 
 protocol ListElementCollectionViewCellDelegate: class {
-    func moreButtonTapped(for element: ListNode?, in cell: ListElementCollectionViewCell)
+    func moreButtonTapped(for element: ListNode?,
+                          in cell: ListElementCollectionViewCell)
 }
 
 class ListElementCollectionViewCell: ListSelectableCell {
@@ -31,23 +32,27 @@ class ListElementCollectionViewCell: ListSelectableCell {
     @IBOutlet weak var syncStatusImageView: UIImageView!
     weak var delegate: ListElementCollectionViewCellDelegate?
 
-    var element: ListNode? {
+    var node: ListNode? {
         didSet {
-            if let element = element {
-                title.text = element.title
-                subtitle.text = element.path
-                iconImageView.image = FileIcon.icon(for: element)
+            guard let node = node else { return }
 
-                syncStatusImageView.isHidden = !(element.syncStatus == .synced)
-                syncStatusImageView.image = element.syncStatusIcon()
+            title.text = node.title
+            subtitle.text = node.path
+            iconImageView.image = FileIcon.icon(for: node)
+        }
+    }
 
-                switch element.syncStatus {
-                case .error:
-                    subtitle.text = LocalizationConstants.Labels.syncFailed
-                case .inProgress:
-                    subtitle.text = LocalizationConstants.Labels.syncing
-                default: break
-                }
+    var syncStatus: ListEntrySyncStatus = .undefined {
+        didSet {
+            syncStatusImageView.isHidden = !(syncStatus != .undefined)
+            syncStatusImageView.image = UIImage(named: syncStatus.rawValue)
+
+            switch syncStatus {
+            case .error:
+                subtitle.text = LocalizationConstants.Labels.syncFailed
+            case .inProgress:
+                subtitle.text = LocalizationConstants.Labels.syncing
+            default: break
             }
         }
     }
@@ -65,6 +70,6 @@ class ListElementCollectionViewCell: ListSelectableCell {
     }
 
     @IBAction func moreButtonTapped(_ sender: UIButton) {
-        delegate?.moreButtonTapped(for: element, in: self)
+        delegate?.moreButtonTapped(for: node, in: self)
     }
 }

--- a/generated/EntityInfo-ContentApp.generated.swift
+++ b/generated/EntityInfo-ContentApp.generated.swift
@@ -119,8 +119,8 @@ extension ListNode {
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { ListNode.markedAsOffline > 1234 }
-    internal static var markedAsOffline: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 12, isPrimaryKey: false) }
+    ///     box.query { ListNode.markedAsOffline == true }
+    internal static var markedAsOffline: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 12, isPrimaryKey: false) }
     /// Generated entity property information.
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
@@ -250,9 +250,9 @@ extension ObjectBox.Property where E == ListNode {
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { .markedAsOffline > 1234 }
+    ///     box.query { .markedAsOffline == true }
 
-    internal static var markedAsOffline: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 12, isPrimaryKey: false) }
+    internal static var markedAsOffline: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 12, isPrimaryKey: false) }
 
     /// Generated entity property information.
     ///


### PR DESCRIPTION
Status for nodes outside the offline tab should be currently displayed as a marked state. Inside the offline tab, folders are unmarked and file status should align with the result of sync operations.

#Refs MOBILEAPPS-655