### PR TITLE
Custom file type support fallback mechanism

### DIFF
--- a/ContentApp/BusinessLayer/Lists/Models/ListNode.swift
+++ b/ContentApp/BusinessLayer/Lists/Models/ListNode.swift
@@ -77,25 +77,27 @@ typealias CreatedNodeType = (String, String, String)
 class ListNode: Hashable, Entity {
     var id: Id = 0 // swiftlint:disable:this identifier_name
     var parentGuid: String?
-    var guid: String
-    var siteID: String
+    var guid = ""
+    var siteID = ""
     var destination: String?
     var mimeType: String?
-    var title: String
-    var path: String
+    var title = ""
+    var path = ""
     var modifiedAt: Date?
-    var favorite: Bool?
-    var trashed: Bool?
+    var favorite: Bool = false
+    var trashed: Bool = false
     var markedAsOffline = false
+    var isFile = false
+    var isFolder = false
 
     // objectbox: convert = { "default": ".unknown" }
-    var nodeType: NodeType
+    var nodeType: NodeType = .unknown
     // objectbox: convert = { "default": ".unknown" }
     var siteRole: SiteRole = .unknown
     // objectbox: convert = { "default": ".undefined" }
-    var syncStatus: SyncStatus
+    var syncStatus: SyncStatus = .undefined
     // objectbox: convert = { "default": ".undefined" }
-    var markedFor: MarkedForStatus
+    var markedFor: MarkedForStatus = .undefined
     // objectbox: convert = { "dbType": "String", "converter": "AllowableOperationsConverter" }
     var allowableOperations: [AllowableOperationsType] = [.unknown]
 
@@ -109,14 +111,15 @@ class ListNode: Hashable, Entity {
          path: String,
          modifiedAt: Date? = nil,
          nodeType: NodeType,
-         favorite: Bool? = nil,
+         favorite: Bool = false,
          syncStatus: SyncStatus = .undefined,
          markedOfflineStatus: MarkedForStatus = .undefined,
          allowableOperations: [String]? = nil,
          siteRole: String? = nil,
          trashed: Bool = false,
-         destination: String? = nil) {
-
+         destination: String? = nil,
+         isFile: Bool = false,
+         isFolder: Bool = false) {
         self.guid = guid
         self.siteID = siteID
         self.parentGuid = parentGuid
@@ -132,19 +135,12 @@ class ListNode: Hashable, Entity {
         self.siteRole = parse(siteRole)
         self.trashed = trashed
         self.destination = destination
+        self.isFile = isFile
+        self.isFolder = isFolder
     }
 
-    init() {
-        guid = ""
-        siteID = ""
-        title = ""
-        path = ""
-        nodeType = .unknown
-        allowableOperations = [.unknown]
-        siteRole = .unknown
-        syncStatus = .undefined
-        markedFor = .undefined
-    }
+    // Default initializer required by ObjectBox
+    init() {}
 
     // MARK: - Public Helpers
 
@@ -162,6 +158,8 @@ class ListNode: Hashable, Entity {
         self.syncStatus = newVersion.syncStatus
         self.markedAsOffline = newVersion.markedAsOffline
         self.markedFor = newVersion.markedFor
+        self.isFile = newVersion.isFile
+        self.isFolder = newVersion.isFolder
     }
 
     static func == (lhs: ListNode, rhs: ListNode) -> Bool {
@@ -171,9 +169,6 @@ class ListNode: Hashable, Entity {
     func shouldUpdate() -> Bool {
         if self.trashed == true {
             return false
-        }
-        if self.favorite == nil {
-            return true
         }
 
         switch self.nodeType {

--- a/ContentApp/BusinessLayer/Lists/Models/Mappers/NodeChildMapper.swift
+++ b/ContentApp/BusinessLayer/Lists/Models/Mappers/NodeChildMapper.swift
@@ -42,8 +42,10 @@ struct NodeChildMapper {
                         path: path,
                         modifiedAt: node.modifiedAt,
                         nodeType: NodeType(rawValue: node.nodeType) ?? .unknown,
-                        favorite: node.isFavorite,
-                        allowableOperations: node.allowableOperations)
+                        favorite: node.isFavorite ?? false,
+                        allowableOperations: node.allowableOperations,
+                        isFile: node.isFile,
+                        isFolder: node.isFolder)
     }
 
     private static func create(from node: NodeChildAssociation) -> ListNode {
@@ -66,8 +68,10 @@ struct NodeChildMapper {
                         path: path,
                         modifiedAt: node.modifiedAt,
                         nodeType: NodeType(rawValue: node.nodeType) ?? .unknown,
-                        favorite: node.isFavorite,
+                        favorite: node.isFavorite ?? false,
                         allowableOperations: node.allowableOperations,
-                        destination: destination)
+                        destination: destination,
+                        isFile: node.isFile,
+                        isFolder: node.isFolder)
     }
 }

--- a/ContentApp/BusinessLayer/Lists/Models/Mappers/ResultsNodeMapper.swift
+++ b/ContentApp/BusinessLayer/Lists/Models/Mappers/ResultsNodeMapper.swift
@@ -42,7 +42,7 @@ struct ResultsNodeMapper {
                         path: path,
                         modifiedAt: node.modifiedAt,
                         nodeType: NodeType(rawValue: node.nodeType) ?? .unknown,
-                        favorite: node.isFavorite,
+                        favorite: node.isFavorite ?? false,
                         allowableOperations: node.allowableOperations)
     }
 }

--- a/ContentApp/BusinessLayer/Lists/Models/Mappers/SharedLinkMapper.swift
+++ b/ContentApp/BusinessLayer/Lists/Models/Mappers/SharedLinkMapper.swift
@@ -38,7 +38,7 @@ struct SharedLinkMapper {
                         path: path,
                         modifiedAt: node.modifiedAt,
                         nodeType: .file,
-                        favorite: node.isFavorite,
+                        favorite: node.isFavorite ?? false,
                         allowableOperations: node.allowableOperations)
     }
 }

--- a/ContentApp/PresentationLayer/Components/ListComponent/ListComponent+DataSource.swift
+++ b/ContentApp/PresentationLayer/Components/ListComponent/ListComponent+DataSource.swift
@@ -23,9 +23,7 @@ private let listSectionCellHeight: CGFloat = 64.0
 private let listSiteCellHeight: CGFloat = 48.0
 
 extension ListComponentViewController: UICollectionViewDelegateFlowLayout,
-                                       UICollectionViewDataSource,
-                                       UICollectionViewDelegate {
-
+                                       UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         referenceSizeForHeaderInSection section: Int) -> CGSize {
@@ -120,21 +118,5 @@ extension ListComponentViewController: UICollectionViewDelegateFlowLayout,
         }
 
         return cell ?? UICollectionViewCell()
-    }
-
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let dataSource = listDataSource else { return }
-        let node = dataSource.listNode(for: indexPath)
-        if dataSource.shouldPreview(node: node) == false { return }
-        if node.trashed == false,
-           let dataSource = listDataSource {
-            listItemActionDelegate?.showPreview(for: node,
-                                                from: dataSource)
-            listActionDelegate?.elementTapped(node: node)
-        } else {
-            listItemActionDelegate?.showActionSheetForListItem(for: node,
-                                                               from: dataSource,
-                                                               delegate: self)
-        }
     }
 }

--- a/ContentApp/PresentationLayer/Components/ListComponent/ListComponentViewController.swift
+++ b/ContentApp/PresentationLayer/Components/ListComponent/ListComponentViewController.swift
@@ -236,6 +236,26 @@ class ListComponentViewController: SystemThemableViewController {
     }
 }
 
+// MARK: - UICollectionViewDelegate
+
+extension ListComponentViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let dataSource = listDataSource else { return }
+        let node = dataSource.listNode(for: indexPath)
+        if dataSource.shouldPreview(node: node) == false { return }
+        if node.trashed == false,
+           let dataSource = listDataSource {
+            listItemActionDelegate?.showPreview(for: node,
+                                                from: dataSource)
+            listActionDelegate?.elementTapped(node: node)
+        } else {
+            listItemActionDelegate?.showActionSheetForListItem(for: node,
+                                                               from: dataSource,
+                                                               delegate: self)
+        }
+    }
+}
+
 // MARK: - ListElementCollectionViewCell Delegate
 
 extension ListComponentViewController: ListElementCollectionViewCellDelegate {
@@ -259,7 +279,6 @@ extension ListComponentViewController: PageFetchableDelegate {
 // MARK: - ListComponentPageUpdatingDelegate
 
 extension ListComponentViewController: ListComponentPageUpdatingDelegate {
-
     func didUpdateList(error: Error?,
                        pagination: Pagination?) {
         guard let isDataSourceEmpty = listDataSource?.isEmpty() else { return }

--- a/ContentApp/PresentationLayer/Files Preview/Screens/FilePreviewViewController.swift
+++ b/ContentApp/PresentationLayer/Files Preview/Screens/FilePreviewViewController.swift
@@ -272,12 +272,12 @@ extension FilePreviewViewController: FilePreviewViewModelDelegate {
 
     func update(listNode: ListNode) {
         if let index = filePreviewViewModel?.actionMenuViewModel?.indexInToolbar(for: .removeFavorite) {
-            let icon = (listNode.favorite ?? false) ? ActionMenuType.removeFavorite.rawValue :
+            let icon = listNode.favorite ? ActionMenuType.removeFavorite.rawValue :
                 ActionMenuType.addFavorite.rawValue
             toolbarActions?[index].image = UIImage(named: icon)
         }
         if let index = filePreviewViewModel?.actionMenuViewModel?.indexInToolbar(for: .addFavorite) {
-            let icon = (listNode.favorite ?? false ) ? ActionMenuType.removeFavorite.rawValue :
+            let icon = listNode.favorite ? ActionMenuType.removeFavorite.rawValue :
                 ActionMenuType.addFavorite.rawValue
             toolbarActions?[index].image = UIImage(named: icon)
         }

--- a/ContentApp/PresentationLayer/List/Sub-Coordinators/FolderChildrenScreenCoordinator.swift
+++ b/ContentApp/PresentationLayer/List/Sub-Coordinators/FolderChildrenScreenCoordinator.swift
@@ -54,17 +54,17 @@ extension FolderChildrenScreenCoordinator: ListItemActionDelegate {
                      from dataSource: ListComponentDataSourceProtocol) {
         switch node.nodeType {
         case .site, .folder, .folderLink:
-            let folderDrillDownCoordinator = FolderChildrenScreenCoordinator(with: self.presenter,
-                                                                             listNode: node)
-            folderDrillDownCoordinator.start()
-            self.folderDrillDownCoordinator = folderDrillDownCoordinator
+            setUpFolderCoordinator(for: node)
         case .file, .fileLink:
-            let filePreviewCoordinator = FilePreviewScreenCoordinator(with: self.presenter,
-                                                                      listNode: node)
-            filePreviewCoordinator.start()
-            self.filePreviewCoordinator = filePreviewCoordinator
+            setUpFileCoordinator(for: node)
         default:
-            AlfrescoLog.error("Unable to show preview for unknown node type")
+            if node.isFile {
+                setUpFileCoordinator(for: node)
+            } else if node.isFolder {
+                setUpFolderCoordinator(for: node)
+            } else {
+                AlfrescoLog.error("Unable to show preview for unknown node type")
+            }
         }
     }
 
@@ -104,5 +104,19 @@ extension FolderChildrenScreenCoordinator: ListItemActionDelegate {
                                                      createNodeViewModelDelegate: delegate)
         coordinator.start()
         createNodeSheetCoordinator = coordinator
+    }
+
+    private func setUpFileCoordinator(for node: ListNode) {
+        let filePreviewCoordinator = FilePreviewScreenCoordinator(with: self.presenter,
+                                                                  listNode: node)
+        filePreviewCoordinator.start()
+        self.filePreviewCoordinator = filePreviewCoordinator
+    }
+
+    private func setUpFolderCoordinator(for node: ListNode) {
+        let folderDrillDownCoordinator = FolderChildrenScreenCoordinator(with: self.presenter,
+                                                                         listNode: node)
+        folderDrillDownCoordinator.start()
+        self.folderDrillDownCoordinator = folderDrillDownCoordinator
     }
 }

--- a/generated/EntityInfo-ContentApp.generated.swift
+++ b/generated/EntityInfo-ContentApp.generated.swift
@@ -38,13 +38,15 @@ extension ListNode: ObjectBox.EntityInspectable {
         try entityBuilder.addProperty(name: "favorite", type: Bool.entityPropertyType, id: 10, uid: 8877005435172031744)
         try entityBuilder.addProperty(name: "trashed", type: Bool.entityPropertyType, id: 11, uid: 8306138110636922368)
         try entityBuilder.addProperty(name: "markedAsOffline", type: Bool.entityPropertyType, id: 12, uid: 8931151636810106368)
+        try entityBuilder.addProperty(name: "isFile", type: Bool.entityPropertyType, id: 19, uid: 7009987470108192768)
+        try entityBuilder.addProperty(name: "isFolder", type: Bool.entityPropertyType, id: 20, uid: 3222472111177428736)
         try entityBuilder.addProperty(name: "nodeType", type: String.entityPropertyType, id: 13, uid: 6370314685970737664)
         try entityBuilder.addProperty(name: "siteRole", type: String.entityPropertyType, id: 14, uid: 8122952080249357824)
         try entityBuilder.addProperty(name: "syncStatus", type: String.entityPropertyType, id: 15, uid: 4676429062915184384)
         try entityBuilder.addProperty(name: "markedFor", type: String.entityPropertyType, id: 18, uid: 1597269330570867456)
         try entityBuilder.addProperty(name: "allowableOperations", type: String.entityPropertyType, id: 17, uid: 186580639668120576)
 
-        try entityBuilder.lastProperty(id: 18, uid: 1597269330570867456)
+        try entityBuilder.lastProperty(id: 20, uid: 3222472111177428736)
     }
 }
 
@@ -107,20 +109,32 @@ extension ListNode {
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { ListNode.favorite > 1234 }
-    internal static var favorite: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 10, isPrimaryKey: false) }
+    ///     box.query { ListNode.favorite == true }
+    internal static var favorite: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 10, isPrimaryKey: false) }
     /// Generated entity property information.
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { ListNode.trashed > 1234 }
-    internal static var trashed: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 11, isPrimaryKey: false) }
+    ///     box.query { ListNode.trashed == true }
+    internal static var trashed: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 11, isPrimaryKey: false) }
     /// Generated entity property information.
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
     ///     box.query { ListNode.markedAsOffline == true }
     internal static var markedAsOffline: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 12, isPrimaryKey: false) }
+    /// Generated entity property information.
+    ///
+    /// You may want to use this in queries to specify fetch conditions, for example:
+    ///
+    ///     box.query { ListNode.isFile == true }
+    internal static var isFile: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 19, isPrimaryKey: false) }
+    /// Generated entity property information.
+    ///
+    /// You may want to use this in queries to specify fetch conditions, for example:
+    ///
+    ///     box.query { ListNode.isFolder == true }
+    internal static var isFolder: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 20, isPrimaryKey: false) }
     /// Generated entity property information.
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
@@ -234,17 +248,17 @@ extension ObjectBox.Property where E == ListNode {
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { .favorite > 1234 }
+    ///     box.query { .favorite == true }
 
-    internal static var favorite: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 10, isPrimaryKey: false) }
+    internal static var favorite: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 10, isPrimaryKey: false) }
 
     /// Generated entity property information.
     ///
     /// You may want to use this in queries to specify fetch conditions, for example:
     ///
-    ///     box.query { .trashed > 1234 }
+    ///     box.query { .trashed == true }
 
-    internal static var trashed: Property<ListNode, Bool?, Void> { return Property<ListNode, Bool?, Void>(propertyId: 11, isPrimaryKey: false) }
+    internal static var trashed: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 11, isPrimaryKey: false) }
 
     /// Generated entity property information.
     ///
@@ -253,6 +267,22 @@ extension ObjectBox.Property where E == ListNode {
     ///     box.query { .markedAsOffline == true }
 
     internal static var markedAsOffline: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 12, isPrimaryKey: false) }
+
+    /// Generated entity property information.
+    ///
+    /// You may want to use this in queries to specify fetch conditions, for example:
+    ///
+    ///     box.query { .isFile == true }
+
+    internal static var isFile: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 19, isPrimaryKey: false) }
+
+    /// Generated entity property information.
+    ///
+    /// You may want to use this in queries to specify fetch conditions, for example:
+    ///
+    ///     box.query { .isFolder == true }
+
+    internal static var isFolder: Property<ListNode, Bool, Void> { return Property<ListNode, Bool, Void>(propertyId: 20, isPrimaryKey: false) }
 
     /// Generated entity property information.
     ///
@@ -334,6 +364,8 @@ internal class ListNodeBinding: ObjectBox.EntityBinding {
         propertyCollector.collect(entity.favorite, at: 2 + 2 * 10)
         propertyCollector.collect(entity.trashed, at: 2 + 2 * 11)
         propertyCollector.collect(entity.markedAsOffline, at: 2 + 2 * 12)
+        propertyCollector.collect(entity.isFile, at: 2 + 2 * 19)
+        propertyCollector.collect(entity.isFolder, at: 2 + 2 * 20)
         propertyCollector.collect(dataOffset: propertyOffset_parentGuid, at: 2 + 2 * 2)
         propertyCollector.collect(dataOffset: propertyOffset_guid, at: 2 + 2 * 3)
         propertyCollector.collect(dataOffset: propertyOffset_siteID, at: 2 + 2 * 4)
@@ -363,6 +395,8 @@ internal class ListNodeBinding: ObjectBox.EntityBinding {
         entity.favorite = entityReader.read(at: 2 + 2 * 10)
         entity.trashed = entityReader.read(at: 2 + 2 * 11)
         entity.markedAsOffline = entityReader.read(at: 2 + 2 * 12)
+        entity.isFile = entityReader.read(at: 2 + 2 * 19)
+        entity.isFolder = entityReader.read(at: 2 + 2 * 20)
         entity.nodeType = optConstruct(NodeType.self, rawValue: entityReader.read(at: 2 + 2 * 13)) ?? .unknown
         entity.siteRole = optConstruct(SiteRole.self, rawValue: entityReader.read(at: 2 + 2 * 14)) ?? .unknown
         entity.syncStatus = optConstruct(SyncStatus.self, rawValue: entityReader.read(at: 2 + 2 * 15)) ?? .undefined

--- a/model-ContentApp.json
+++ b/model-ContentApp.json
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:4924419163766400768",
-      "lastPropertyId": "18:1597269330570867456",
+      "lastPropertyId": "20:3222472111177428736",
       "name": "ListNode",
       "properties": [
         {
@@ -93,6 +93,16 @@
           "id": "18:1597269330570867456",
           "name": "markedFor",
           "type": 9
+        },
+        {
+          "id": "19:7009987470108192768",
+          "name": "isFile",
+          "type": 1
+        },
+        {
+          "id": "20:3222472111177428736",
+          "name": "isFolder",
+          "type": 1
         }
       ],
       "relations": []

--- a/model-ContentApp.json.bak
+++ b/model-ContentApp.json.bak
@@ -5,7 +5,7 @@
   "entities": [
     {
       "id": "1:4924419163766400768",
-      "lastPropertyId": "17:186580639668120576",
+      "lastPropertyId": "18:1597269330570867456",
       "name": "ListNode",
       "properties": [
         {
@@ -85,13 +85,13 @@
           "type": 9
         },
         {
-          "id": "16:1132591789422262528",
-          "name": "markedForStatus",
+          "id": "17:186580639668120576",
+          "name": "allowableOperations",
           "type": 9
         },
         {
-          "id": "17:186580639668120576",
-          "name": "allowableOperations",
+          "id": "18:1597269330570867456",
+          "name": "markedFor",
           "type": 9
         }
       ],
@@ -106,7 +106,9 @@
   "modelVersionParserMinimum": 4,
   "retiredEntityUids": [],
   "retiredIndexUids": [],
-  "retiredPropertyUids": [],
+  "retiredPropertyUids": [
+    1132591789422262528
+  ],
   "retiredRelationUids": [],
   "version": 1
 }


### PR DESCRIPTION
When node type mapping fails, fallback to the isFile, isFolder properties of the node and try to open the content given that the mime type information is accurate.

#Refs MOBILEAPPS-695