### PR TITLE
Improve list fetch next content page

### DIFF
--- a/ContentApp/PresentationLayer/Components/ListComponent/ListComponent+DataSource.swift
+++ b/ContentApp/PresentationLayer/Components/ListComponent/ListComponent+DataSource.swift
@@ -117,6 +117,11 @@ extension ListComponentViewController: UICollectionViewDelegateFlowLayout,
             cell?.subtitle.text = ""
         }
 
+        if isPaginationEnabled && collectionView.lastItemIndexPath() == indexPath {
+            self.collectionView.pageDelegate?.fetchNextContentPage(for: self.collectionView,
+                                                                   itemAtIndexPath: indexPath)
+        }
+
         return cell ?? UICollectionViewCell()
     }
 }


### PR DESCRIPTION
iPad Pro 12.9 - Only first page with Libraries is loaded in Portrait mode
#Refs MOBILEAPPS-625