### PR TITLE
Update search result on main thread

### DIFF
--- a/ContentApp/BusinessLayer/Search/ViewModels/ResultsViewModel.swift
+++ b/ContentApp/BusinessLayer/Search/ViewModels/ResultsViewModel.swift
@@ -44,7 +44,10 @@ class ResultsViewModel: PageFetchingViewModel, EventObservable {
 
 extension ResultsViewModel: SearchViewModelDelegate {
     func handle(results: [ListNode]?, pagination: Pagination?, error: Error?) {
-        updateResults(results: results, pagination: pagination, error: error)
+        DispatchQueue.main.async { [weak self] in
+            guard let sSelf = self else { return }
+            sSelf.updateResults(results: results, pagination: pagination, error: error)
+        }
     }
 }
 


### PR DESCRIPTION
Searching for specific terms will cause endless search calls done and then app crashes if cancelling the search
#Refs MOBILEAPPS-608