### PR TITLE
Dismiss SearchController programmatically

### DIFF
--- a/ContentApp/PresentationLayer/Components/SystemSearchViewController.swift
+++ b/ContentApp/PresentationLayer/Components/SystemSearchViewController.swift
@@ -51,7 +51,7 @@ class SystemSearchViewController: SystemThemableViewController {
     func cancelSearchMode() {
         searchViewModel?.lastSearchedString = nil
         self.navigationItem.searchController?.searchBar.text = ""
-        self.navigationItem.searchController?.dismiss(animated: false, completion: nil)
+        self.navigationItem.searchController?.isActive = false
     }
 
     func configureNavigationBar() {


### PR DESCRIPTION
The Cancel button from Search bar remains visible if search flow is closed by tapping on tab bar
#Refs MOBILEAPPS-704