### PR TITLE
Fixed full screen preview file

### DIFF
--- a/ContentApp/PresentationLayer/Files Preview/Screens/FilePreviewViewController.swift
+++ b/ContentApp/PresentationLayer/Files Preview/Screens/FilePreviewViewController.swift
@@ -257,7 +257,12 @@ extension FilePreviewViewController: FilePreviewViewModelDelegate {
 
     func enableFullscreenContentExperience() {
         needsContraintsForFullScreen = true
-        activateContraintsToSuperview()
+        DispatchQueue.main.async { [weak self] in
+            guard let sSelf = self else { return }
+            if sSelf.needsContraintsForFullScreen {
+                sSelf.activateContraintsToSuperview()
+            }
+        }
     }
 
     func willPreparePreview() {


### PR DESCRIPTION
The background of the actions bar remains visible when viewing images in full screen
#Refs MOBILEAPPS-705