### PR TITLE
Remove UnknownAllowableOpr when sync children

### DIFF
--- a/ContentApp/BusinessLayer/Sync/SyncOperationFactory.swift
+++ b/ContentApp/BusinessLayer/Sync/SyncOperationFactory.swift
@@ -172,6 +172,7 @@ class SyncOperationFactory {
                     sSelf.nodesWithChildren[node]?.append(contentsOf: onlineNodes)
 
                     for onlineNode in onlineNodes {
+                        onlineNode.removeAllowableOperationUnknown()
                         if onlineNode.isAFolderType() {
                             let queriedNode = listNodeDataAccessor.query(node: onlineNode)
                             onlineNode.markedAsOffline = queriedNode?.markedAsOffline ?? false


### PR DESCRIPTION
Endless loading spinner displayed on Action sheet for an item that is not from user's account
#Refs MOBILEAPPS-708