### PR TITLE
Remove PullToRefresh when offline mode is active

### DIFF
--- a/ContentApp/BusinessLayer/Lists/ViewModels/OfflineFoldreDrillViewModel.swift
+++ b/ContentApp/BusinessLayer/Lists/ViewModels/OfflineFoldreDrillViewModel.swift
@@ -107,6 +107,10 @@ extension OfflineFolderDrillViewModel: ListComponentDataSourceProtocol {
         return true
     }
 
+    func shouldDisplayPullToRefreshOffline() -> Bool {
+        true
+    }
+
     func performListAction() {
         // Do nothing
     }

--- a/ContentApp/BusinessLayer/Lists/ViewModels/OfflineViewModel.swift
+++ b/ContentApp/BusinessLayer/Lists/ViewModels/OfflineViewModel.swift
@@ -141,6 +141,10 @@ extension OfflineViewModel: ListViewModelProtocol {
         return false
     }
 
+    func shouldDisplayPullToRefreshOffline() -> Bool {
+        true
+    }
+
     func performListAction() {
         let connectivityService = coordinatorServices?.connectivityService
         if connectivityService?.status == .cellular &&

--- a/ContentApp/BusinessLayer/Lists/ViewModels/Protocols/ListComponentDataSourceProtocol.swift
+++ b/ContentApp/BusinessLayer/Lists/ViewModels/Protocols/ListComponentDataSourceProtocol.swift
@@ -46,6 +46,7 @@ protocol ListComponentDataSourceProtocol: class {
     func shouldDisplayNodePath() -> Bool
     func shouldDisplayListActionButton() -> Bool
     func shouldDisplayMoreButton(node: ListNode) -> Bool
+    func shouldDisplayPullToRefreshOffline() -> Bool
     func shouldEnableListActionButton() -> Bool
     func shouldPreview(node: ListNode) -> Bool
     func syncStatus(for node: ListNode) -> ListEntrySyncStatus
@@ -79,6 +80,10 @@ extension ListComponentDataSourceProtocol {
 
     func shouldDisplayMoreButton(node: ListNode) -> Bool {
         return true
+    }
+
+    func shouldDisplayPullToRefreshOffline() -> Bool {
+        false
     }
 
     func shouldPreview(node: ListNode) -> Bool {

--- a/ContentApp/PresentationLayer/Components/ListComponent/ListComponentViewController.swift
+++ b/ContentApp/PresentationLayer/Components/ListComponent/ListComponentViewController.swift
@@ -236,6 +236,14 @@ class ListComponentViewController: SystemThemableViewController {
         let connectivityService = coordinatorServices?.connectivityService
         if connectivityService?.hasInternetConnection() == false {
             didUpdateList(error: NSError(), pagination: nil)
+
+            if listDataSource?.shouldDisplayPullToRefreshOffline() == false {
+                refreshControl?.removeFromSuperview()
+            }
+        } else {
+            if let refreshControl = self.refreshControl, refreshControl.superview == nil {
+                collectionView.addSubview(refreshControl)
+            }
         }
         listActionButton.isEnabled = connectivityService?.hasInternetConnection() ?? false
     }


### PR DESCRIPTION
Doing a refresh list while device is offline is causing it not to work after getting the device online
#Refs MOBILEAPPS-710