### PR TITLE
Fixed rotate animation when flipping Camera

### DIFF
--- a/ContentApp/Modules/CameraKit/Components/SessionPreview.swift
+++ b/ContentApp/Modules/CameraKit/Components/SessionPreview.swift
@@ -173,6 +173,19 @@ class SessionPreview: UIView {
             UIPinchGestureRecognizer(target: self,
                                      action: #selector(handleZoomPinch(recognizer:)))
         addGestureRecognizer(zoomPinchGesture)
+        
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didRotate),
+                                               name: UIDevice.orientationDidChangeNotification,
+                                               object: nil)
+    }
+    
+    @objc private func didRotate() {
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            previewLayer?.connection?.videoOrientation = UIDevice.current.orientation.cameraOrientation
+        } else {
+            previewLayer?.connection?.videoOrientation = .portrait
+        }
     }
     
     private func addFocusView(at point: CGPoint) {


### PR DESCRIPTION
Camera viewport is displayed upside down when flipping the iPad from landscape to landscape or portrait to portrait #Refs MOBILEAPPS-745