### PR TITLE
Disable more button on nodes that correspond to failed operations in lists

### DIFF
--- a/ContentApp/BusinessLayer/File Preview/ViewModels/FilePreviewViewModel.swift
+++ b/ContentApp/BusinessLayer/File Preview/ViewModels/FilePreviewViewModel.swift
@@ -160,6 +160,11 @@ class FilePreviewViewModel {
         nodeOperations.renditionTimer?.invalidate()
     }
 
+    func shouldDisplayActionsToolbar() -> Bool {
+        guard let listNode = listNode else { return  false}
+        return listNode.syncStatus != .error
+    }
+
     // MARK: - Analytics
 
     func sendAnalyticsForPreviewFile(success: Bool) {

--- a/ContentApp/BusinessLayer/Lists/ViewModels/FolderDrillViewModel.swift
+++ b/ContentApp/BusinessLayer/Lists/ViewModels/FolderDrillViewModel.swift
@@ -34,6 +34,8 @@ class FolderDrillViewModel: ListComponentViewModel {
             return false
         case .inProgress:
             return false
+        case .error:
+            return false
         default:
             return true
         }

--- a/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.swift
+++ b/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.swift
@@ -31,6 +31,10 @@ class ListElementCollectionViewCell: ListSelectableCell {
     @IBOutlet weak var syncStatusImageView: UIImageView!
     weak var delegate: ListElementCollectionViewCellDelegate?
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
     var node: ListNode? {
         didSet {
             guard let node = node else { return }

--- a/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.xib
+++ b/ContentApp/PresentationLayer/List/Screens/Cells/ListElementCollectionViewCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>


### PR DESCRIPTION
- Additionally hide the toolbar when viewing local node content that failed to complete upload / sync

Refs #MOBILEAPPS-742